### PR TITLE
Fixed Null exception on BeginAuthorize for MVC projects

### DIFF
--- a/New/Libraries/LinqToTwitter.AspNet/MvcAuthorizer.cs
+++ b/New/Libraries/LinqToTwitter.AspNet/MvcAuthorizer.cs
@@ -8,6 +8,8 @@ namespace LinqToTwitter
 {
     public class MvcAuthorizer : AspNetAuthorizer
     {
+        private string _authUrl;
+
         public async  Task<ActionResult> BeginAuthorizationAsync()
         {
             return await BeginAuthorizationAsync(Callback);
@@ -16,14 +18,13 @@ namespace LinqToTwitter
         public async Task<ActionResult> BeginAuthorizationAsync(Uri callback)
         {
             if (GoToTwitterAuthorization == null)
-                GoToTwitterAuthorization = authUrl =>
-                        HttpContext.Current.Response.Redirect(authUrl, false); 
+                GoToTwitterAuthorization = authUrl => { _authUrl = authUrl; };
 
             Callback = callback;
 
             await base.BeginAuthorizeAsync(callback);
 
-            return new EmptyResult();
+            return new RedirectResult(_authUrl);
         }
     }
 }


### PR DESCRIPTION
Updated MVCAuthorizer to use RedirectResult instead of Response.Redirect.
MVC does not properly handle Response.Redirect, I have updated the MVC
specific authorizer to use the MVC best practice for redirection. This
also solves a bug where HttpContext.Current was null for some MVC
projects (including mine).