### PR TITLE
implemented include_email parameter for verify_credentials request

### DIFF
--- a/src/LinqToTwitter/LinqToTwitter.Shared/Account/Account.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Account/Account.cs
@@ -23,6 +23,12 @@ namespace LinqToTwitter
         public bool IncludeEntities { get; set; }
 
         /// <summary>
+        /// Includes the user's email address in response (requires whitelisting,
+        /// see https://dev.twitter.com/rest/reference/get/account/verify_credentials)
+        /// </summary>
+        public bool IncludeEmail { get; set; }
+
+        /// <summary>
         /// User returned by VerifyCredentials Queries
         /// </summary>
         public User User { get; set; }

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Account/AccountRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Account/AccountRequestProcessor.cs
@@ -37,6 +37,12 @@ namespace LinqToTwitter
         internal bool IncludeEntities { get; set; }
 
         /// <summary>
+        /// Includes the user's email address in response (requires whitelisting,
+        /// see https://dev.twitter.com/rest/reference/get/account/verify_credentials)
+        /// </summary>
+        internal bool IncludeEmail { get; set; }
+
+        /// <summary>
         /// extracts parameters from lambda
         /// </summary>
         /// <param name="lambdaExpression">lambda expression with where clause</param>
@@ -49,7 +55,8 @@ namespace LinqToTwitter
                    new List<string> { 
                        "Type",
                        "SkipStatus",
-                       "IncludeEntities"
+                       "IncludeEntities",
+                       "IncludeEmail"
                    })
                    .Parameters;
         }
@@ -96,6 +103,12 @@ namespace LinqToTwitter
                 urlParams.Add(new QueryParameter("include_entities", parameters["IncludeEntities"].ToLower()));
             }
 
+            if (parameters.ContainsKey("IncludeEmail"))
+            {
+                IncludeEmail = bool.Parse(parameters["IncludeEmail"]);
+                urlParams.Add(new QueryParameter("include_email", parameters["IncludeEmail"].ToLower()));
+            }
+
             return req;
         }
 
@@ -127,6 +140,7 @@ namespace LinqToTwitter
                 acct.Type = Type;
                 acct.SkipStatus = SkipStatus;
                 acct.IncludeEntities = IncludeEntities;
+                acct.IncludeEmail = IncludeEmail;
             }
 
             return new List<Account> { acct }.OfType<T>().ToList();

--- a/src/LinqToTwitter/LinqToTwitter.Shared/User/User.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/User/User.cs
@@ -67,6 +67,7 @@ namespace LinqToTwitter
             FollowRequestSent = user.GetValue<bool>("follow_request_sent");
             Status = new Status(user.GetValue<JsonData>("status"));
             CursorMovement = new Cursors(user);
+            Email = user.GetValue<string>("email");
         }
 
         /// <summary>
@@ -372,5 +373,11 @@ namespace LinqToTwitter
         /// Available sizes to use in account banners.
         /// </summary>
         public List<BannerSize> BannerSizes { get; set; }
+
+        /// <summary>
+        /// User's email-address (null if not filled in on app is
+        /// lacking whitelisting)
+        /// </summary>
+        public string Email { get; set; }
     }
 }

--- a/src/LinqToTwitter/LinqToTwitter.Tests/AccountTests/AccountRequestProcessorTests.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Tests/AccountTests/AccountRequestProcessorTests.cs
@@ -90,7 +90,8 @@ namespace LinqToTwitterPcl.Tests.AccountTests
                 acct => 
                     acct.Type == AccountType.Settings &&
                     acct.SkipStatus == true &&
-                    acct.IncludeEntities == true;
+                    acct.IncludeEntities == true &&
+                    acct.IncludeEmail == true;
             var lambdaExpression = expression as LambdaExpression;
 
             var queryParams = target.GetParameters(lambdaExpression);
@@ -104,19 +105,23 @@ namespace LinqToTwitterPcl.Tests.AccountTests
             Assert.IsTrue(
                 queryParams.Contains(
                     new KeyValuePair<string, string>("IncludeEntities", "True")));
+            Assert.IsTrue(
+                queryParams.Contains(
+                    new KeyValuePair<string, string>("IncludeEmail", "True")));
         }
 
         [TestMethod]
         public void BuildUrl_Constructs_VerifyCredentials_Url()
         {
-            const string ExpectedUrl = "https://api.twitter.com/1.1/account/verify_credentials.json?skip_status=true&include_entities=false";
+            const string ExpectedUrl = "https://api.twitter.com/1.1/account/verify_credentials.json?skip_status=true&include_entities=false&include_email=true";
             var acctReqProc = new AccountRequestProcessor<Account> { BaseUrl = "https://api.twitter.com/1.1/" };
             var parameters =
                 new Dictionary<string, string>
                 {
                         { "Type", ((int)AccountType.VerifyCredentials).ToString(CultureInfo.InvariantCulture) },
                         { "SkipStatus", true.ToString() },
-                        { "IncludeEntities", false.ToString() }
+                        { "IncludeEntities", false.ToString() },
+                        { "IncludeEmail", true.ToString() }
                 };
 
             Request req = acctReqProc.BuildUrl(parameters);


### PR DESCRIPTION
I had to be able to requests a user's e-mail address for an automatic OAuth login workflow for a recent work project. Solves #41.