### PR TITLE
issuse #87 added the parameter for the since as a date time

### DIFF
--- a/New/Libraries/LinqToTwitterPcl/Search/Search.cs
+++ b/New/Libraries/LinqToTwitterPcl/Search/Search.cs
@@ -46,6 +46,11 @@ namespace LinqToTwitter
         public DateTime Until { get; set; }
 
         /// <summary>
+        /// Return tweets after this date
+        /// </summary>
+        public DateTime Since { get; set; }
+
+        /// <summary>
         /// last status ID
         /// </summary>
         public ulong SinceID { get; set; }

--- a/New/Libraries/LinqToTwitterPcl/Search/SearchRequestProcessor.cs
+++ b/New/Libraries/LinqToTwitterPcl/Search/SearchRequestProcessor.cs
@@ -60,6 +60,11 @@ namespace LinqToTwitter
         private DateTime Until { get; set; }
 
         /// <summary>
+        /// Return tweets after this date
+        /// </summary>
+        private DateTime Since { get; set; }
+
+        /// <summary>
         /// last status ID
         /// </summary>
         private ulong SinceID { get; set; }
@@ -93,6 +98,7 @@ namespace LinqToTwitter
                        "ResultType",
                        "Count",
                        "Until",
+                       "Since",
                        "SinceID",
                        "MaxID",
                        "IncludeEntities"
@@ -168,6 +174,12 @@ namespace LinqToTwitter
                 urlParams.Add(new QueryParameter("until",  Until.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
             }
 
+            if (parameters.ContainsKey("Since"))
+            {
+                Since = DateTime.Parse(parameters["Since"]).Date;
+                urlParams.Add(new QueryParameter("since", Since.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
+            }
+
             if (parameters.ContainsKey("SinceID"))
             {
                 SinceID = ulong.Parse(parameters["SinceID"]);
@@ -233,6 +245,7 @@ namespace LinqToTwitter
                 SearchLanguage = SearchLanguage,
                 Locale = Locale,
                 Until = Until.Date,
+                Since = Since.Date,
                 ResultType = ResultType,
                 IncludeEntities = IncludeEntities,
                 Statuses =

--- a/New/Tests/LinqToTwitterPcl.Tests/SearchTests/SearchRequestProcessorTests.cs
+++ b/New/Tests/LinqToTwitterPcl.Tests/SearchTests/SearchRequestProcessorTests.cs
@@ -68,7 +68,7 @@ namespace LinqToTwitterPcl.Tests.SearchTests
         [TestMethod]
         public void BuildUrl_Includes_Parameters()
         {
-            const string ExpectedUrl = "https://api.twitter.com/1.1/search/tweets.json?q=LINQ%20to%20Twitter&geocode=40.757929%2C-73.985506%2C25km&lang=en&count=10&until=2011-07-04&since_id=1&result_type=popular&include_entities=false";
+            const string ExpectedUrl = "https://api.twitter.com/1.1/search/tweets.json?q=LINQ%20to%20Twitter&geocode=40.757929%2C-73.985506%2C25km&lang=en&count=10&until=2011-07-04&since=2010-05-04&since_id=1&result_type=popular&include_entities=false";
             var searchReqProc = new SearchRequestProcessor<Search> { BaseUrl = "https://api.twitter.com/1.1/" };
             var parameters =
                 new Dictionary<string, string>
@@ -80,6 +80,7 @@ namespace LinqToTwitterPcl.Tests.SearchTests
                     { "Query", "LINQ to Twitter" },
                     { "SinceID", "1" },
                     { "Until", new DateTime(2011, 7, 4).ToString() },
+                    { "Since", new DateTime(2010, 5, 4).ToString() },
                     { "ResultType", ResultType.Popular.ToString() },
                     { "IncludeEntities", false.ToString() }
                };

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Search/Search.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Search/Search.cs
@@ -46,6 +46,11 @@ namespace LinqToTwitter
         public DateTime Until { get; set; }
 
         /// <summary>
+        /// Return tweets after this date
+        /// </summary>
+        public DateTime Since { get; set; }
+
+        /// <summary>
         /// last status ID
         /// </summary>
         public ulong SinceID { get; set; }

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Search/SearchRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Search/SearchRequestProcessor.cs
@@ -60,6 +60,11 @@ namespace LinqToTwitter
         internal DateTime Until { get; set; }
 
         /// <summary>
+        /// Return tweets after this date
+        /// </summary>
+        internal DateTime Since { get; set; }
+
+        /// <summary>
         /// last status ID
         /// </summary>
         internal ulong SinceID { get; set; }
@@ -98,6 +103,7 @@ namespace LinqToTwitter
                        "ResultType",
                        "Count",
                        "Until",
+                       "Since",
                        "SinceID",
                        "MaxID",
                        "IncludeEntities",
@@ -174,6 +180,12 @@ namespace LinqToTwitter
                 urlParams.Add(new QueryParameter("until",  Until.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
             }
 
+            if (parameters.ContainsKey("Since"))
+            {
+                Since = DateTime.Parse(parameters["Since"]).Date;
+                urlParams.Add(new QueryParameter("since", Since.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
+            }
+
             if (parameters.ContainsKey("SinceID"))
             {
                 SinceID = ulong.Parse(parameters["SinceID"]);
@@ -245,6 +257,7 @@ namespace LinqToTwitter
                 SearchLanguage = SearchLanguage,
                 Locale = Locale,
                 Until = Until.Date,
+                Since = Since.Date,
                 ResultType = ResultType,
                 IncludeEntities = IncludeEntities,
                 Statuses =

--- a/src/LinqToTwitter/LinqToTwitter.Tests/SearchTests/SearchRequestProcessorTests.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Tests/SearchTests/SearchRequestProcessorTests.cs
@@ -72,7 +72,7 @@ namespace LinqToTwitterPcl.Tests.SearchTests
         [TestMethod]
         public void BuildUrl_Includes_Parameters()
         {
-            const string ExpectedUrl = "https://api.twitter.com/1.1/search/tweets.json?q=LINQ%20to%20Twitter&geocode=40.757929%2C-73.985506%2C25km&lang=en&count=10&until=2011-07-04&since_id=1&result_type=popular&include_entities=false&tweet_mode=extended";
+            const string ExpectedUrl = "https://api.twitter.com/1.1/search/tweets.json?q=LINQ%20to%20Twitter&geocode=40.757929%2C-73.985506%2C25km&lang=en&count=10&until=2011-07-04&since=2010-05-04&since_id=1&result_type=popular&include_entities=false&tweet_mode=extended";
             var searchReqProc = new SearchRequestProcessor<Search> { BaseUrl = "https://api.twitter.com/1.1/" };
             var parameters =
                 new Dictionary<string, string>
@@ -84,6 +84,7 @@ namespace LinqToTwitterPcl.Tests.SearchTests
                     { "Query", "LINQ to Twitter" },
                     { "SinceID", "1" },
                     { "Until", new DateTime(2011, 7, 4).ToString() },
+                    { "Since", new DateTime(2010, 5, 4).ToString() },
                     { "ResultType", ResultType.Popular.ToString() },
                     { "IncludeEntities", false.ToString() },
                     { nameof(Search.TweetMode), ((int)TweetMode.Extended).ToString() }


### PR DESCRIPTION
Fixing Issue #87 
https://github.com/JoeMayo/LinqToTwitter/issues/87

There is a parameter for since like until, but it's all the tweets since date X.

> superhero since:2015-12-21	containing “superhero” and sent since date “2015-12-21” (year-month-day).

https://dev.twitter.com/rest/public/search