### PR TITLE
Unify all enum parsing to use Enum.Parse, not int.Parse

### DIFF
--- a/src/LinqToTwitter/LinqToTwitter.Shared/Account/AccountRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Account/AccountRequestProcessor.cs
@@ -72,7 +72,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<AccountType>(parameters[TypeParam]);
+            Type = RequestProcessorHelper.ParseEnum<AccountType>(parameters[TypeParam]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/AccountActivity/AccountActivityRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/AccountActivity/AccountActivityRequestProcessor.cs
@@ -61,7 +61,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey(nameof(Type)))
                 throw new ArgumentException($"You must set {nameof(Type)}.", nameof(Type));
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<AccountActivityType>(parameters[nameof(Type)]);
+            Type = RequestProcessorHelper.ParseEnum<AccountActivityType>(parameters[nameof(Type)]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Blocks/BlocksRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Blocks/BlocksRequestProcessor.cs
@@ -96,7 +96,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<BlockingType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<BlockingType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Common/RequestProcessorHelper.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Common/RequestProcessorHelper.cs
@@ -9,35 +9,25 @@ namespace LinqToTwitter
     internal class RequestProcessorHelper
     {
         /// <summary>
-        /// All queries have an enum type that specifies the query sub-type;
-        /// This method determines if the type parameter parsed is a string
-        /// or int and performs the conversion to the enum type.
+        /// Some query parameters represent enum types. Different languages
+        /// handle such values in different ways when translating query expressions.
+        /// This method performs the conversion to the enum type regardless of whether
+        /// the parameter string represents an int value or a textual enum case name.
         /// </summary>
         /// <remarks>
-        /// Delphi enums come to the IRequestProcessor as pneumonic strings,
+        /// Delphi and F# enums come to the IRequestProcessor as pneumonic strings,
         /// but C# enums arrive as the underlying int type of the enum;
         /// therefore, we must determine what we're working with to succeed.
         /// </remarks>
         /// <typeparam name="T">Enum type to convert to</typeparam>
-        /// <param name="queryType">
-        /// Either a string enum member name (from Delphi Prism)
+        /// <param name="enumValue">
+        /// Either a string enum member name (from Delphi Prism or F#)
         /// or an underlying int value (from C#/VB)
         /// </param>
-        /// <returns>Requested enum type</returns>
-        internal static T ParseQueryEnumType<T>(string queryType)
+        /// <returns>Parameter value translated to the requested enum type</returns>
+        internal static T ParseEnum<T>(string enumValue)
         {
-            T statusType;
-
-            if (queryType.GetType() == typeof(string))
-            {
-                statusType = (T)Enum.Parse(typeof(T), queryType, /*ignoreCase:*/ true);
-            }
-            else
-            {
-                statusType = (T)Enum.ToObject(typeof(T), int.Parse(queryType));
-            }
-
-            return statusType;
+            return (T)Enum.Parse(typeof(T), enumValue, /*ignoreCase:*/ true);
         }
 
         /// <summary>

--- a/src/LinqToTwitter/LinqToTwitter.Shared/DirectMessage/DirectMessageRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/DirectMessage/DirectMessageRequestProcessor.cs
@@ -105,7 +105,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<DirectMessageType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<DirectMessageType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/DirectMessageEvents/DirectMessageEventsRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/DirectMessageEvents/DirectMessageEventsRequestProcessor.cs
@@ -73,7 +73,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey(nameof(Type)))
                 throw new ArgumentException($"You must set {nameof(Type)}.", nameof(Type));
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<DirectMessageEventsType>(parameters[nameof(Type)]);
+            Type = RequestProcessorHelper.ParseEnum<DirectMessageEventsType>(parameters[nameof(Type)]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Favorites/FavoritesRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Favorites/FavoritesRequestProcessor.cs
@@ -151,7 +151,7 @@ namespace LinqToTwitter
 
             if (parameters.ContainsKey(nameof(TweetMode)))
             {
-                TweetMode = (TweetMode)int.Parse(parameters[nameof(TweetMode)]);
+                TweetMode = RequestProcessorHelper.ParseEnum<TweetMode>(parameters[nameof(TweetMode)]);
                 urlParams.Add(new QueryParameter("tweet_mode", TweetMode.ToString().ToLower()));
             }
 

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Favorites/FavoritesRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Favorites/FavoritesRequestProcessor.cs
@@ -97,7 +97,7 @@ namespace LinqToTwitter
             if (!parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<FavoritesType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<FavoritesType>(parameters["Type"]);
 
             return BuildFavoritesUrlParameters(parameters);
         }

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Friendship/FriendshipRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Friendship/FriendshipRequestProcessor.cs
@@ -122,7 +122,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<FriendshipType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<FriendshipType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Geo/GeoRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Geo/GeoRequestProcessor.cs
@@ -126,7 +126,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<GeoType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<GeoType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Help/HelpRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Help/HelpRequestProcessor.cs
@@ -44,7 +44,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<HelpType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<HelpType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/List/ListRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/List/ListRequestProcessor.cs
@@ -208,7 +208,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey(TypeParam))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<ListType>(parameters[TypeParam]);
+            Type = RequestProcessorHelper.ParseEnum<ListType>(parameters[TypeParam]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Media/MediaRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Media/MediaRequestProcessor.cs
@@ -72,7 +72,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey(nameof(Type)))
                 throw new ArgumentException("You must set Type.", nameof(Type));
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<MediaType>(parameters[nameof(Type)]);
+            Type = RequestProcessorHelper.ParseEnum<MediaType>(parameters[nameof(Type)]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Mute/MuteRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Mute/MuteRequestProcessor.cs
@@ -78,7 +78,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<MuteType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<MuteType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/SavedSearch/SavedSearchRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/SavedSearch/SavedSearchRequestProcessor.cs
@@ -60,7 +60,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", "Type");
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<SavedSearchType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<SavedSearchType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Search/SearchRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Search/SearchRequestProcessor.cs
@@ -200,7 +200,7 @@ namespace LinqToTwitter
 
             if (parameters.ContainsKey(nameof(TweetMode)))
             {
-                TweetMode = (TweetMode) int.Parse(parameters[nameof(TweetMode)]);
+                TweetMode = RequestProcessorHelper.ParseEnum<TweetMode>(parameters[nameof(TweetMode)]);
                 urlParams.Add(new QueryParameter("tweet_mode", TweetMode.ToString().ToLower()));
             }
 

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Search/SearchRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Search/SearchRequestProcessor.cs
@@ -115,7 +115,7 @@ namespace LinqToTwitter
         public Request BuildUrl(Dictionary<string, string> parameters)
         {
             if (parameters.ContainsKey("Type"))
-                Type = RequestProcessorHelper.ParseQueryEnumType<SearchType>(parameters["Type"]);
+                Type = RequestProcessorHelper.ParseEnum<SearchType>(parameters["Type"]);
             else
                 throw new ArgumentException("Type is required", "Type");
 
@@ -188,7 +188,7 @@ namespace LinqToTwitter
 
             if (parameters.ContainsKey("ResultType"))
             {
-                ResultType = RequestProcessorHelper.ParseQueryEnumType<ResultType>(parameters["ResultType"]);
+                ResultType = RequestProcessorHelper.ParseEnum<ResultType>(parameters["ResultType"]);
                 urlParams.Add(new QueryParameter("result_type" , ResultType.ToString().ToLower()));
             }
 

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Status/StatusRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Status/StatusRequestProcessor.cs
@@ -336,7 +336,7 @@ namespace LinqToTwitter
 
             if (parameters.ContainsKey(nameof(TweetMode)))
             {
-                TweetMode = (TweetMode) int.Parse(parameters[nameof(TweetMode)]);
+                TweetMode = RequestProcessorHelper.ParseEnum<TweetMode>(parameters[nameof(TweetMode)]);
                 urlParams.Add(new QueryParameter("tweet_mode", TweetMode.ToString().ToLower()));
             }
 
@@ -362,7 +362,7 @@ namespace LinqToTwitter
 
             if (parameters.ContainsKey(nameof(TweetMode)))
             {
-                TweetMode = (TweetMode)int.Parse(parameters[nameof(TweetMode)]);
+                TweetMode = RequestProcessorHelper.ParseEnum<TweetMode>(parameters[nameof(TweetMode)]);
                 urlParams.Add(new QueryParameter("tweet_mode", TweetMode.ToString().ToLower()));
             }
 
@@ -409,7 +409,7 @@ namespace LinqToTwitter
 
             if (parameters.ContainsKey(nameof(TweetMode)))
             {
-                TweetMode = (TweetMode) int.Parse(parameters[nameof(TweetMode)]);
+                TweetMode = RequestProcessorHelper.ParseEnum<TweetMode>(parameters[nameof(TweetMode)]);
                 urlParams.Add(new QueryParameter("tweet_mode", TweetMode.ToString().ToLower()));
             }
 
@@ -480,7 +480,7 @@ namespace LinqToTwitter
 
             if (parameters.ContainsKey("OEmbedAlign"))
             {
-                OEmbedAlign = (EmbeddedStatusAlignment)Enum.Parse(typeof(EmbeddedStatusAlignment), parameters["OEmbedAlign"], true);
+                OEmbedAlign = RequestProcessorHelper.ParseEnum<EmbeddedStatusAlignment>(parameters["OEmbedAlign"]);
                 urlParams.Add(new QueryParameter("align", OEmbedAlign.ToString().ToLower()));
             }
 
@@ -498,7 +498,7 @@ namespace LinqToTwitter
 
             if (parameters.ContainsKey(nameof(TweetMode)))
             {
-                TweetMode = (TweetMode) int.Parse(parameters[nameof(TweetMode)]);
+                TweetMode = RequestProcessorHelper.ParseEnum<TweetMode>(parameters[nameof(TweetMode)]);
                 urlParams.Add(new QueryParameter("tweet_mode", TweetMode.ToString().ToLower()));
             }
 
@@ -566,7 +566,7 @@ namespace LinqToTwitter
 
             if (parameters.ContainsKey(nameof(TweetMode)))
             {
-                TweetMode = (TweetMode) int.Parse(parameters[nameof(TweetMode)]);
+                TweetMode = RequestProcessorHelper.ParseEnum<TweetMode>(parameters[nameof(TweetMode)]);
                 urlParams.Add(new QueryParameter("tweet_mode", TweetMode.ToString().ToLower()));
             }
 

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Status/StatusRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Status/StatusRequestProcessor.cs
@@ -216,7 +216,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<StatusType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<StatusType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Streaming/ControlStreamRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Streaming/ControlStreamRequestProcessor.cs
@@ -74,7 +74,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<ControlStreamType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<ControlStreamType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Streaming/StreamingRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Streaming/StreamingRequestProcessor.cs
@@ -130,7 +130,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
  
-            Type = RequestProcessorHelper.ParseQueryEnumType<StreamingType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<StreamingType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Trends/TrendRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Trends/TrendRequestProcessor.cs
@@ -78,7 +78,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<TrendType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<TrendType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/User/UserRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/User/UserRequestProcessor.cs
@@ -142,7 +142,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<UserType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<UserType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Vine/VineRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Vine/VineRequestProcessor.cs
@@ -88,7 +88,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey("Type"))
                 throw new ArgumentException("You must set Type.", TypeParam);
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<VineType>(parameters["Type"]);
+            Type = RequestProcessorHelper.ParseEnum<VineType>(parameters["Type"]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Shared/WelcomeMessages/WelcomeMessageRequestProcessor.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/WelcomeMessages/WelcomeMessageRequestProcessor.cs
@@ -73,7 +73,7 @@ namespace LinqToTwitter
             if (parameters == null || !parameters.ContainsKey(nameof(Type)))
                 throw new ArgumentException($"You must set {nameof(Type)}.", nameof(Type));
 
-            Type = RequestProcessorHelper.ParseQueryEnumType<WelcomeMessageType>(parameters[nameof(Type)]);
+            Type = RequestProcessorHelper.ParseEnum<WelcomeMessageType>(parameters[nameof(Type)]);
 
             switch (Type)
             {

--- a/src/LinqToTwitter/LinqToTwitter.Tests/FavoritesTests/FavoritesRequestProcessorTests.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Tests/FavoritesTests/FavoritesRequestProcessorTests.cs
@@ -105,6 +105,29 @@ namespace LinqToTwitterPcl.Tests.FavoritesTests
         }
 
         [TestMethod]
+        public void BuildUrl_Handles_String_TweetMode()
+        {
+            const string ExpectedUrl = "https://api.twitter.com/1.1/favorites/list.json?user_id=123&screen_name=JoeMayo&count=100&since_id=456&max_id=789&include_entities=true&tweet_mode=extended";
+            var favReqProc = new FavoritesRequestProcessor<Favorites> { BaseUrl = "https://api.twitter.com/1.1/" };
+            var parameters =
+                new Dictionary<string, string>
+                {
+                    { nameof(Favorites.Type), FavoritesType.Favorites.ToString() },
+                    { nameof(Favorites.UserID), "123" },
+                    { nameof(Favorites.ScreenName), "JoeMayo" },
+                    { nameof(Favorites.Count), "100" },
+                    { nameof(Favorites.SinceID), "456" },
+                    { nameof(Favorites.MaxID), "789" },
+                    { nameof(Favorites.IncludeEntities), true.ToString() },
+                    { nameof(Favorites.TweetMode), TweetMode.Extended.ToString().ToLower() } // "extended" string, not "1"
+                };
+
+            Request req = favReqProc.BuildUrl(parameters);
+
+            Assert.AreEqual(ExpectedUrl, req.FullUrl);
+        }
+
+        [TestMethod]
         public void BuildUrl_Throws_On_Missing_Type_Param()
         {
             var favReqProc = new FavoritesRequestProcessor<Favorites> { BaseUrl = "https://api.twitter.com/1.1/" };

--- a/src/LinqToTwitter/LinqToTwitter.Tests/SearchTests/SearchRequestProcessorTests.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Tests/SearchTests/SearchRequestProcessorTests.cs
@@ -95,6 +95,31 @@ namespace LinqToTwitterPcl.Tests.SearchTests
         }
 
         [TestMethod]
+        public void BuildUrl_Handles_String_TweetMode()
+        {
+            const string ExpectedUrl = "https://api.twitter.com/1.1/search/tweets.json?q=LINQ%20to%20Twitter&geocode=40.757929%2C-73.985506%2C25km&lang=en&count=10&until=2011-07-04&since_id=1&result_type=popular&include_entities=false&tweet_mode=extended";
+            var searchReqProc = new SearchRequestProcessor<Search> { BaseUrl = "https://api.twitter.com/1.1/" };
+            var parameters =
+                new Dictionary<string, string>
+                {
+                    { "Type", SearchType.Search.ToString() },
+                    { "GeoCode", "40.757929,-73.985506,25km" },
+                    { "SearchLanguage", "en" },
+                    { "Count", "10" },
+                    { "Query", "LINQ to Twitter" },
+                    { "SinceID", "1" },
+                    { "Until", new DateTime(2011, 7, 4).ToString() },
+                    { "ResultType", ResultType.Popular.ToString() },
+                    { "IncludeEntities", false.ToString() },
+                    { nameof(Search.TweetMode), TweetMode.Extended.ToString().ToLower() } // "extended" string, not "1"
+               };
+
+            Request req = searchReqProc.BuildUrl(parameters);
+
+            Assert.AreEqual(ExpectedUrl, req.FullUrl);
+        }
+
+        [TestMethod]
         public void BuildUrl_Throws_When_Parameters_Null()
         {
             var searchReqProc = new SearchRequestProcessor<Search> { BaseUrl = "https://api.twitter.com/1.1/search/" };

--- a/src/LinqToTwitter/LinqToTwitter.Tests/StatusTests/StatusRequestProcessorTests.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Tests/StatusTests/StatusRequestProcessorTests.cs
@@ -157,6 +157,23 @@ namespace LinqToTwitterPcl.Tests.StatusTests
         }
 
         [TestMethod]
+        public void BuildUrl_Handles_String_TweetMode_Conversations()
+        {
+            const string ExpectedUrl = "https://api.twitter.com/1.1/conversation/show.json?id=123&tweet_mode=extended";
+            var statProc = new StatusRequestProcessor<Status> { BaseUrl = "https://api.twitter.com/1.1/" };
+            var parameters = new Dictionary<string, string>
+            {
+                { "Type", ((int)StatusType.Conversation).ToString() },
+                { "ID", "123" },
+                { nameof(Status.TweetMode), TweetMode.Extended.ToString().ToLower() }  // "extended" string, not "1"
+            };
+
+            Request req = statProc.BuildUrl(parameters);
+
+            Assert.AreEqual(ExpectedUrl, req.FullUrl);
+        }
+
+        [TestMethod]
         public void BuildUrl_Conversations_Throws_On_Missing_ID()
         {
             const string ExpectedParam = "ID";
@@ -400,6 +417,49 @@ namespace LinqToTwitterPcl.Tests.StatusTests
         }
 
         [TestMethod]
+        public void BuildUrl_Handles_String_TweetMode_Retweeters()
+        {
+            const string ExpectedUrl = "https://api.twitter.com/1.1/statuses/retweeters/ids.json?id=5&cursor=7&tweet_mode=extended";
+            var reqProc = new StatusRequestProcessor<Status>
+            {
+                Type = StatusType.User,
+                BaseUrl = "https://api.twitter.com/1.1/"
+            };
+            var parameters = new Dictionary<string, string>
+            {
+                { "Type", ((int)StatusType.Retweeters).ToString() },
+                { "ID", "5" },
+                { "Cursor", "7" },
+                { nameof(Status.TweetMode), TweetMode.Extended.ToString().ToLower() } // "extended" string, not "1"
+            };
+
+            Request req = reqProc.BuildUrl(parameters);
+
+            Assert.AreEqual(ExpectedUrl, req.FullUrl);
+        }
+
+        [TestMethod]
+        public void BuildUrl_Handles_String_TweetMode()
+        {
+            const string ExpectedUrl = "https://api.twitter.com/1.1/statuses/home_timeline.json?count=5&tweet_mode=extended";
+            var reqProc = new StatusRequestProcessor<Status>
+            {
+                Type = StatusType.User,
+                BaseUrl = "https://api.twitter.com/1.1/"
+            };
+            var parameters = new Dictionary<string, string>
+            {
+                { "Type", ((int)StatusType.Home).ToString() },
+                { "Count", "5" },
+                { nameof(Status.TweetMode), TweetMode.Extended.ToString().ToLower() } // "extended" string, not "1"
+            };
+
+            Request req = reqProc.BuildUrl(parameters);
+
+            Assert.AreEqual(ExpectedUrl, req.FullUrl);
+        }
+
+        [TestMethod]
         public void BuildUrl_RetweetedBy_Throws_On_Missing_ID()
         {
             const string ExpectedParam = "ID";
@@ -459,6 +519,31 @@ namespace LinqToTwitterPcl.Tests.StatusTests
                 { nameof(Status.Map), true.ToString() },
                 { nameof(Status.IncludeAltText), true.ToString() },
                 { nameof(Status.TweetMode), ((int)TweetMode.Extended).ToString() }
+            };
+
+            Request req = reqProc.BuildUrl(parameters);
+
+            Assert.AreEqual(ExpectedUrl, req.FullUrl);
+        }
+
+        [TestMethod]
+        public void BuildUrl_Handles_String_TweetMode_Lookup()
+        {
+            const string ExpectedUrl = "https://api.twitter.com/1.1/statuses/lookup.json?id=1%2C2%2C3&include_entities=true&map=true&trim_user=true&tweet_mode=extended&include_ext_alt_text=true";
+            var reqProc = new StatusRequestProcessor<Status>
+            {
+                Type = StatusType.Lookup,
+                BaseUrl = "https://api.twitter.com/1.1/"
+            };
+            var parameters = new Dictionary<string, string>
+            {
+                { nameof(Status.Type), ((int)StatusType.Lookup).ToString() },
+                { nameof(Status.TweetIDs), "1,2,3" },
+                { nameof(Status.IncludeEntities), true.ToString() },
+                { nameof(Status.TrimUser), true.ToString() },
+                { nameof(Status.Map), true.ToString() },
+                { nameof(Status.IncludeAltText), true.ToString() },
+                { nameof(Status.TweetMode), TweetMode.Extended.ToString().ToLower() } // "extended" string, not "1"
             };
 
             Request req = reqProc.BuildUrl(parameters);


### PR DESCRIPTION
ref https://github.com/JoeMayo/LinqToTwitter/issues/125

I noticed that throughout the codebase, most enum parameters were being parsed with `Enum.Parse`, which handles both numeric "value" strings and "name" strings.

e.g.

https://github.com/JoeMayo/LinqToTwitter/blob/e22fa89f00fba07926d8a89524463354c6313bb3/src/LinqToTwitter/LinqToTwitter.Shared/Status/StatusRequestProcessor.cs#L483
https://github.com/JoeMayo/LinqToTwitter/blob/e22fa89f00fba07926d8a89524463354c6313bb3/src/LinqToTwitter/LinqToTwitter.Shared/Common/RequestProcessorHelper.cs#L33

However `TweetMode` for some reason was always being parsed with `int.Parse`, which only handles the integral value case. This led to the incompatibility mentioned in the issue.

This PR changes all enum parsing code to use a shared helper method that uses case-insensitive `Enum.Parse`
