### PR TITLE
Add ConfigureAwait(false) to "await" calls

### DIFF
--- a/src/LinqToTwitter/LinqToTwitter.AspNet/LinqToTwitter.AspNet.csproj
+++ b/src/LinqToTwitter/LinqToTwitter.AspNet/LinqToTwitter.AspNet.csproj
@@ -90,6 +90,10 @@
       <Name>LinqToTwitter.netstandard</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\ConfigureAwaitChecker.Analyzer.2.0.0\analyzers\dotnet\cs\ConfigureAwaitChecker.Analyzer.dll" />
+    <Analyzer Include="..\packages\ConfigureAwaitChecker.Analyzer.2.0.0\analyzers\dotnet\cs\ConfigureAwaitChecker.Lib.dll" />
+  </ItemGroup>
   <Import Project="..\LinqToTwitter.Shared.aspnet\LinqToTwitter.Shared.aspnet.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />

--- a/src/LinqToTwitter/LinqToTwitter.AspNet/MvcAuthorizer.cs
+++ b/src/LinqToTwitter/LinqToTwitter.AspNet/MvcAuthorizer.cs
@@ -10,7 +10,7 @@ namespace LinqToTwitter
 
         public async  Task<ActionResult> BeginAuthorizationAsync()
         {
-            return await BeginAuthorizationAsync(Callback);
+            return await BeginAuthorizationAsync(Callback).ConfigureAwait(false);
         }
 
         public async Task<ActionResult> BeginAuthorizationAsync(Uri callback)
@@ -20,7 +20,7 @@ namespace LinqToTwitter
 
             Callback = callback;
 
-            await base.BeginAuthorizeAsync(callback);
+            await base.BeginAuthorizeAsync(callback).ConfigureAwait(false);
 
             return new RedirectResult(_authUrl);
         }

--- a/src/LinqToTwitter/LinqToTwitter.AspNet/packages.config
+++ b/src/LinqToTwitter/LinqToTwitter.AspNet/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ConfigureAwaitChecker.Analyzer" version="2.0.0" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.6" targetFramework="net461" />
   <package id="Microsoft.AspNet.Razor" version="3.2.6" targetFramework="net461" userInstalled="true" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.6" targetFramework="net461" userInstalled="true" />

--- a/src/LinqToTwitter/LinqToTwitter.AspNetCore/LinqToTwitter.AspNetCore.csproj
+++ b/src/LinqToTwitter/LinqToTwitter.AspNetCore/LinqToTwitter.AspNetCore.csproj
@@ -9,6 +9,7 @@
     <Description>A LINQ Provider for the Twitter API</Description>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Session" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/src/LinqToTwitter/LinqToTwitter.AspNetCore/MvcAuthorizer.cs
+++ b/src/LinqToTwitter/LinqToTwitter.AspNetCore/MvcAuthorizer.cs
@@ -10,7 +10,7 @@ namespace LinqToTwitter
 
         public async  Task<ActionResult> BeginAuthorizationAsync()
         {
-            return await BeginAuthorizationAsync(Callback);
+            return await BeginAuthorizationAsync(Callback).ConfigureAwait(false);
         }
 
         public async Task<ActionResult> BeginAuthorizationAsync(Uri callback)
@@ -20,7 +20,7 @@ namespace LinqToTwitter
 
             Callback = callback;
 
-            await base.BeginAuthorizeAsync(callback);
+            await base.BeginAuthorizeAsync(callback).ConfigureAwait(false);
 
             return new RedirectResult(_authUrl);
         }

--- a/src/LinqToTwitter/LinqToTwitter.Core/LinqToTwitter.Core.csproj
+++ b/src/LinqToTwitter/LinqToTwitter.Core/LinqToTwitter.Core.csproj
@@ -16,6 +16,7 @@
     <Version>5.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />

--- a/src/LinqToTwitter/LinqToTwitter.Shared.aspnet/AspNetAuthorizer.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared.aspnet/AspNetAuthorizer.cs
@@ -51,7 +51,7 @@ namespace LinqToTwitter
         /// <param name="callback">This is where you want Twitter to redirect to after authorization</param>
         public async Task BeginAuthorizeAsync()
         {
-            await BeginAuthorizeAsync(Callback);
+            await BeginAuthorizeAsync(Callback).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace LinqToTwitter
             if (GoToTwitterAuthorization == null)
                 throw new InvalidOperationException("You must provide an Action<string> delegate/lambda for GoToTwitterAuthorization.");
 
-            await GetRequestTokenAsync(callback.ToString());
+            await GetRequestTokenAsync(callback.ToString()).ConfigureAwait(false);
 
             string authUrl = PrepareAuthorizeUrl(ForceLogin);
             GoToTwitterAuthorization(authUrl);
@@ -119,7 +119,7 @@ namespace LinqToTwitter
             {
                 { "oauth_verifier", pin }
             };
-            await GetAccessTokenAsync(accessTokenParams);
+            await GetAccessTokenAsync(accessTokenParams).ConfigureAwait(false);
         }
     }
 }

--- a/src/LinqToTwitter/LinqToTwitter.Shared.net/Net/TwitterExecute.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared.net/Net/TwitterExecute.cs
@@ -175,7 +175,7 @@ namespace LinqToTwitter
 
                 await TwitterErrorHandler.ThrowIfErrorAsync(response).ConfigureAwait(false);
 
-                Stream stream = await CreateStream(response);
+                Stream stream = await CreateStream(response).ConfigureAwait(false);
 
                 const int CarriageReturn = 0x0D;
                 const int LineFeed = 0x0A;
@@ -308,7 +308,7 @@ namespace LinqToTwitter
 
                 HttpResponseMessage msg = await client.PostAsync(url, multiPartContent, cancelToken).ConfigureAwait(false);
 
-                return await HandleResponseAsync(msg);
+                return await HandleResponseAsync(msg).ConfigureAwait(false);
             }
         }
 
@@ -333,11 +333,11 @@ namespace LinqToTwitter
         {
             WriteLog(url, nameof(PostMediaAsync));
 
-            ulong mediaID = await InitAsync(url, data, postData, name, fileName, contentType, mediaCategory, shared, cancelToken);
+            ulong mediaID = await InitAsync(url, data, postData, name, fileName, contentType, mediaCategory, shared, cancelToken).ConfigureAwait(false);
 
-            await AppendChunksAsync(url, mediaID, data, name, fileName, contentType, cancelToken);
+            await AppendChunksAsync(url, mediaID, data, name, fileName, contentType, cancelToken).ConfigureAwait(false);
 
-            return await FinalizeAsync(url, mediaID, cancelToken);
+            return await FinalizeAsync(url, mediaID, cancelToken).ConfigureAwait(false);
         }
 
         async Task<ulong> InitAsync(string url, byte[] data, IDictionary<string, string> postData, string name, string fileName, string contentType, string mediaCategory, bool shared, CancellationToken cancelToken)
@@ -367,7 +367,7 @@ namespace LinqToTwitter
 
                 HttpResponseMessage msg = await client.PostAsync(url, multiPartContent, cancelToken).ConfigureAwait(false);
 
-                string response = await HandleResponseAsync(msg);
+                string response = await HandleResponseAsync(msg).ConfigureAwait(false);
 
                 var media = JsonMapper.ToObject(response);
                 var mediaID = media.GetValue<ulong>("media_id");
@@ -405,7 +405,7 @@ namespace LinqToTwitter
 
                     HttpResponseMessage msg = await client.PostAsync(url, multiPartContent, cancelToken).ConfigureAwait(false);
 
-                    await HandleResponseAsync(msg);
+                    await HandleResponseAsync(msg).ConfigureAwait(false);
                 } 
             }
         }
@@ -426,7 +426,7 @@ namespace LinqToTwitter
 
                 HttpResponseMessage msg = await client.PostAsync(url, multiPartContent, cancelToken).ConfigureAwait(false);
 
-                return await HandleResponseAsync(msg);
+                return await HandleResponseAsync(msg).ConfigureAwait(false);
             }
         }
 
@@ -466,7 +466,7 @@ namespace LinqToTwitter
                 else
                     msg = await client.PutAsync(url, content).ConfigureAwait(false);
 
-                return await HandleResponseAsync(msg);
+                return await HandleResponseAsync(msg).ConfigureAwait(false);
             }
         }
 
@@ -508,7 +508,7 @@ namespace LinqToTwitter
                 else
                     msg = await client.PostAsync(url, content).ConfigureAwait(false);
 
-                return await HandleResponseAsync(msg);
+                return await HandleResponseAsync(msg).ConfigureAwait(false);
             }
         }
   

--- a/src/LinqToTwitter/LinqToTwitter.Shared.net/Security/ApplicationOnlyAuthorizer.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared.net/Security/ApplicationOnlyAuthorizer.cs
@@ -50,7 +50,7 @@ namespace LinqToTwitter
             {
                 var msg = await client.SendAsync(req).ConfigureAwait(false);
 
-                await TwitterErrorHandler.ThrowIfErrorAsync(msg);
+                await TwitterErrorHandler.ThrowIfErrorAsync(msg).ConfigureAwait(false);
 
                 string response = await msg.Content.ReadAsStringAsync().ConfigureAwait(false);
 
@@ -77,7 +77,7 @@ namespace LinqToTwitter
             {
                 var msg = await client.SendAsync(req).ConfigureAwait(false);
 
-                await TwitterErrorHandler.ThrowIfErrorAsync(msg);
+                await TwitterErrorHandler.ThrowIfErrorAsync(msg).ConfigureAwait(false);
 
                 string response = await msg.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/LinqToTwitter/LinqToTwitter.Shared.net/Security/AuthorizerBase.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared.net/Security/AuthorizerBase.cs
@@ -122,7 +122,7 @@ namespace LinqToTwitter
             if (AccessType != AuthAccessType.NoChange)
                 Parameters.Add("x_auth_access_type", AccessType.ToString().ToLower());
 
-            string response = await HttpGetAsync(OAuthRequestTokenUrl, Parameters);
+            string response = await HttpGetAsync(OAuthRequestTokenUrl, Parameters).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(response))
                 throw new ArgumentNullException("Empty response to request token response from Twitter.");

--- a/src/LinqToTwitter/LinqToTwitter.Shared.xamarin/Net/TwitterExecute.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared.xamarin/Net/TwitterExecute.cs
@@ -176,7 +176,7 @@ namespace LinqToTwitter
 
                 await TwitterErrorHandler.ThrowIfErrorAsync(response).ConfigureAwait(false);
 
-                Stream stream = await CreateStream(response);
+                Stream stream = await CreateStream(response).ConfigureAwait(false);
 
                 const int CarriageReturn = 0x0D;
                 const int LineFeed = 0x0A;
@@ -301,7 +301,7 @@ namespace LinqToTwitter
 
                 HttpResponseMessage msg = await client.PostAsync(url, multiPartContent, cancelToken).ConfigureAwait(false);
 
-                return await HandleResponseAsync(msg);
+                return await HandleResponseAsync(msg).ConfigureAwait(false);
             }
         }
 
@@ -326,11 +326,11 @@ namespace LinqToTwitter
         {
             WriteLog(url, "PostMediaAsync");
 
-            ulong mediaID = await InitAsync(url, data, postData, name, fileName, contentType, mediaCategory, shared, cancelToken);
+            ulong mediaID = await InitAsync(url, data, postData, name, fileName, contentType, mediaCategory, shared, cancelToken).ConfigureAwait(false);
 
-            await AppendChunksAsync(url, mediaID, data, name, fileName, contentType, cancelToken);
+            await AppendChunksAsync(url, mediaID, data, name, fileName, contentType, cancelToken).ConfigureAwait(false);
 
-            return await FinalizeAsync(url, mediaID, cancelToken);
+            return await FinalizeAsync(url, mediaID, cancelToken).ConfigureAwait(false);
         }
 
         async Task<ulong> InitAsync(string url, byte[] data, IDictionary<string, string> postData, string name, string fileName, string contentType, string mediaCategory, bool shared, CancellationToken cancelToken)
@@ -359,7 +359,7 @@ namespace LinqToTwitter
 
                 HttpResponseMessage msg = await client.PostAsync(url, multiPartContent, cancelToken).ConfigureAwait(false);
 
-                string response = await HandleResponseAsync(msg);
+                string response = await HandleResponseAsync(msg).ConfigureAwait(false);
 
                 var media = JsonMapper.ToObject(response);
                 var mediaID = media.GetValue<ulong>("media_id");
@@ -397,7 +397,7 @@ namespace LinqToTwitter
 
                     HttpResponseMessage msg = await client.PostAsync(url, multiPartContent, cancelToken).ConfigureAwait(false);
 
-                    await HandleResponseAsync(msg);
+                    await HandleResponseAsync(msg).ConfigureAwait(false);
                 }
             }
         }
@@ -417,7 +417,7 @@ namespace LinqToTwitter
 
                 HttpResponseMessage msg = await client.PostAsync(url, multiPartContent, cancelToken).ConfigureAwait(false);
 
-                return await HandleResponseAsync(msg);
+                return await HandleResponseAsync(msg).ConfigureAwait(false);
             }
         }
 
@@ -453,7 +453,7 @@ namespace LinqToTwitter
                         await client.PostAsync(url, content).ConfigureAwait(false) :
                         await client.PutAsync(url, content).ConfigureAwait(false);
 
-                return await HandleResponseAsync(msg);
+                return await HandleResponseAsync(msg).ConfigureAwait(false);
             }
         }
 
@@ -495,7 +495,7 @@ namespace LinqToTwitter
                 else
                     msg = await client.PostAsync(url, content).ConfigureAwait(false);
 
-                return await HandleResponseAsync(msg);
+                return await HandleResponseAsync(msg).ConfigureAwait(false);
             }
         }
   

--- a/src/LinqToTwitter/LinqToTwitter.Shared.xamarin/Security/ApplicationOnlyAuthorizer.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared.xamarin/Security/ApplicationOnlyAuthorizer.cs
@@ -44,7 +44,7 @@ namespace LinqToTwitter
             {
                 var msg = await client.SendAsync(req).ConfigureAwait(false);
 
-                await TwitterErrorHandler.ThrowIfErrorAsync(msg);
+                await TwitterErrorHandler.ThrowIfErrorAsync(msg).ConfigureAwait(false);
 
                 string response = await msg.Content.ReadAsStringAsync().ConfigureAwait(false);
 
@@ -67,7 +67,7 @@ namespace LinqToTwitter
             {
                 var msg = await client.SendAsync(req).ConfigureAwait(false);
 
-                await TwitterErrorHandler.ThrowIfErrorAsync(msg);
+                await TwitterErrorHandler.ThrowIfErrorAsync(msg).ConfigureAwait(false);
 
                 string response = await msg.Content.ReadAsStringAsync().ConfigureAwait(false);
 

--- a/src/LinqToTwitter/LinqToTwitter.Shared.xamarin/Security/AuthorizerBase.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared.xamarin/Security/AuthorizerBase.cs
@@ -122,7 +122,7 @@ namespace LinqToTwitter
             if (AccessType != AuthAccessType.NoChange)
                 Parameters.Add("x_auth_access_type", AccessType.ToString().ToLower());
 
-            string response = await HttpGetAsync(OAuthRequestTokenUrl, Parameters);
+            string response = await HttpGetAsync(OAuthRequestTokenUrl, Parameters).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(response))
                 throw new ArgumentNullException("Empty response to request token response from Twitter.");

--- a/src/LinqToTwitter/LinqToTwitter.Shared/DirectMessageEvents/TwitterContextDirectMessageEventsCommands.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/DirectMessageEvents/TwitterContextDirectMessageEventsCommands.cs
@@ -27,7 +27,7 @@ namespace LinqToTwitter
                 }
             };
 
-            return await NewDirectMessageEventAsync(recipientID, text, attachment);
+            return await NewDirectMessageEventAsync(recipientID, text, attachment).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace LinqToTwitter
                 }
             };
 
-            return await NewDirectMessageEventAsync(recipientID, text, attachment);
+            return await NewDirectMessageEventAsync(recipientID, text, attachment).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace LinqToTwitter
                 }
             };
 
-            return await NewDirectMessageEventAsync(recipientID, text, attachment);
+            return await NewDirectMessageEventAsync(recipientID, text, attachment).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace LinqToTwitter
         /// <returns>Direct message events data.</returns>
         public async Task<DirectMessageEvents> NewDirectMessageEventAsync(ulong recipientID, string text, CancellationToken cancelToken = default(CancellationToken))
         {
-            return await NewDirectMessageEventAsync(recipientID, text, attachment: null);
+            return await NewDirectMessageEventAsync(recipientID, text, attachment: null).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace LinqToTwitter
                 Options = options
             };
 
-            return await NewDirectMessageEventAsync(recipientID, text, attachment: null, quickReply: quickReply);
+            return await NewDirectMessageEventAsync(recipientID, text, attachment: null, quickReply: quickReply).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace LinqToTwitter
         /// <returns>Direct message events data.</returns>
         public async Task<DirectMessageEvents> RequestButtonChoiceAsync(ulong recipientID, string text, IEnumerable<CallToAction> callToActions, CancellationToken cancelToken = default(CancellationToken))
         {
-            return await NewDirectMessageEventAsync(recipientID, text, attachment: null, quickReply: null, callToActions: callToActions);
+            return await NewDirectMessageEventAsync(recipientID, text, attachment: null, quickReply: null, callToActions: callToActions).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/LinqToTwitter/LinqToTwitter.Shared/LinqToTwitter/TwitterExtensions.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/LinqToTwitter/TwitterExtensions.cs
@@ -44,12 +44,12 @@ namespace LinqToTwitter
                         {
                             observer.OnError(ex);
                         }
-                    });
+                    }).ConfigureAwait(false);
 
                     observer.OnCompleted();
                 });
 
-            return await Task.FromResult(observableContent);
+            return await Task.FromResult(observableContent).ConfigureAwait(false);
         }
 
         public static async Task<List<T>> ToListAsync<T>(this IQueryable<T> query)

--- a/src/LinqToTwitter/LinqToTwitter.Shared/Media/TwitterContextMediaCommands.cs
+++ b/src/LinqToTwitter/LinqToTwitter.Shared/Media/TwitterContextMediaCommands.cs
@@ -23,7 +23,7 @@ namespace LinqToTwitter
         /// <returns>Status containing new reply</returns>
         public virtual async Task<Media> UploadMediaAsync(byte[] media, string mediaType, string mediaCategory, bool shared = false, CancellationToken cancelToken = default(CancellationToken))
         {
-            return await UploadMediaAsync(media, mediaType, null, mediaCategory, shared, cancelToken);
+            return await UploadMediaAsync(media, mediaType, null, mediaCategory, shared, cancelToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/LinqToTwitter/LinqToTwitter.net/LinqToTwitter.net.csproj
+++ b/src/LinqToTwitter/LinqToTwitter.net/LinqToTwitter.net.csproj
@@ -67,6 +67,10 @@
     <None Include="LinqToTwitter.snk" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\ConfigureAwaitChecker.Analyzer.2.0.0\analyzers\dotnet\cs\ConfigureAwaitChecker.Analyzer.dll" />
+    <Analyzer Include="..\packages\ConfigureAwaitChecker.Analyzer.2.0.0\analyzers\dotnet\cs\ConfigureAwaitChecker.Lib.dll" />
+  </ItemGroup>
   <Import Project="..\LinqToTwitter.Shared\LinqToTwitter.Shared.projitems" Label="Shared" />
   <Import Project="..\LinqToTwitter.Shared.net\LinqToTwitter.Shared.net.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/src/LinqToTwitter/LinqToTwitter.net/packages.config
+++ b/src/LinqToTwitter/LinqToTwitter.net/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ConfigureAwaitChecker.Analyzer" version="2.0.0" targetFramework="portable45-net45+win8+wpa81" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="portable45-net45+win8+wpa81" />
   <package id="Rx-Core" version="2.2.5" targetFramework="portable45-net45+win8+wpa81" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="portable45-net45+win8+wpa81" />

--- a/src/LinqToTwitter/LinqToTwitter.netstandard/LinqToTwitter.netstandard.csproj
+++ b/src/LinqToTwitter/LinqToTwitter.netstandard/LinqToTwitter.netstandard.csproj
@@ -14,6 +14,7 @@
   <Import Project="..\LinqToTwitter.Shared.net\LinqToTwitter.Shared.net.projitems" Label="Shared" />
 
   <ItemGroup>
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Reactive.Core" Version="4.0.0" />
     <PackageReference Include="System.Reactive.Interfaces" Version="4.0.0" />

--- a/src/LinqToTwitter/LinqToTwitter.xamarin/LinqToTwitter.xamarin.csproj
+++ b/src/LinqToTwitter/LinqToTwitter.xamarin/LinqToTwitter.xamarin.csproj
@@ -78,6 +78,10 @@
     <None Include="LinqToTwitter.snk" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\ConfigureAwaitChecker.Analyzer.2.0.0\analyzers\dotnet\cs\ConfigureAwaitChecker.Analyzer.dll" />
+    <Analyzer Include="..\packages\ConfigureAwaitChecker.Analyzer.2.0.0\analyzers\dotnet\cs\ConfigureAwaitChecker.Lib.dll" />
+  </ItemGroup>
   <Import Project="..\LinqToTwitter.Shared\LinqToTwitter.Shared.projitems" Label="Shared" />
   <Import Project="..\LinqToTwitter.Shared.xamarin\LinqToTwitter.Shared.xamarin.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/src/LinqToTwitter/LinqToTwitter.xamarin/packages.config
+++ b/src/LinqToTwitter/LinqToTwitter.xamarin/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ConfigureAwaitChecker.Analyzer" version="2.0.0" targetFramework="portable45-net45+win8+wp8" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="portable45-net45+win8+wp8" userInstalled="true" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable45-net45+win8+wp8" userInstalled="true" />
   <package id="Microsoft.Bcl.Compression" version="3.9.85" targetFramework="portable45-net45+win8+wp8" userInstalled="true" />


### PR DESCRIPTION
I had a problem after upgrading LinqToTwitter from an older version that didn't have async methods to the new version that does - I was getting the "classic deadlock problem" in my ASP.NET MVC 4 application when my sync code was blocking, waiting the async task to complete in LinqToTwitter.

I worked around it by disabling the ASP.NET synchronization context before blocking for the result but I thought that it might be useful to add ".ConfigureAwait(false)" to the library everywhere that an "await" is present as this is the commonly given advice for library-writers.

I added an analyzer to the projects to help me do this initial work and to hopefully make it harder for new "await" calls to be added in the future that do not include ConfigureAwait(false) - it can be very easy for them to start sneaking in!

I did this on a Windows 8 PC and so I was unable to load the projects that rely on the Windows 10 SDK.

You made a comment in issue #68 that you aimed to use ConfigureAwait(false) everywhere, so I hope that these changes are welcome.. but if the places that I've changed intentionally did not use specify ConfigureAwait then I may have been too aggressive with where I added it? (For example, the analyzer recommends adding it to *all* await calls, even something like Task.FromResult(..) and I'm not 100% sure if it is as vital there or not, since "await Task.FromResult(..)" *may* effectively be handled more like sync code than async..?) I thought that it would be easier to add it everywhere and not worry about it than to try to cherry pick where was best and where might be less important!