### PR TITLE
Update TwitterContextDirectMessageEventsCommands.cs

### DIFF
--- a/src/LinqToTwitter5/LinqToTwitter.Shared/DirectMessageEvents/TwitterContextDirectMessageEventsCommands.cs
+++ b/src/LinqToTwitter5/LinqToTwitter.Shared/DirectMessageEvents/TwitterContextDirectMessageEventsCommands.cs
@@ -144,7 +144,7 @@ namespace LinqToTwitter
         /// <param name="callToActions">List of Call to Action, which creates buttons in the message.</param>
         /// <param name="cancelToken">Async cancellation token.</param>
         /// <returns>Direct message events data.</returns>
-        async Task<DirectMessageEvents> NewDirectMessageEventAsync(ulong recipientID, string text, Attachment attachment = null, QuickReply quickReply = null, IEnumerable<CallToAction> callToActions = null, CancellationToken cancelToken = default(CancellationToken))
+        public async Task<DirectMessageEvents> NewDirectMessageEventAsync(ulong recipientID, string text, Attachment attachment = null, QuickReply quickReply = null, IEnumerable<CallToAction> callToActions = null, CancellationToken cancelToken = default(CancellationToken))
         {
             if (recipientID == default(ulong))
                 throw new ArgumentException($"{nameof(recipientID)} must be set.", nameof(recipientID));


### PR DESCRIPTION
Need to be able to access the private version of NewDirectMessageEventAsync in order to create a DM that has both a media attachment and CTA buttons.