### PR TITLE
NullReferenceException on ASP.NET not using offline.access

### DIFF
--- a/Samples/LinqToTwitter6/ASP.NET/LinqToTwitter.MVC.CSharp/LinqToTwitter.MVC.CSharp/LinqToTwitter.MVC.CSharp.csproj
+++ b/Samples/LinqToTwitter6/ASP.NET/LinqToTwitter.MVC.CSharp/LinqToTwitter.MVC.CSharp/LinqToTwitter.MVC.CSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <Reference Include="LinqToTwitter">
-      <HintPath>..\..\..\..\..\src\LinqToTwitter6\LinqToTwitter.AspNet\bin\Debug\net5.0\LinqToTwitter.dll</HintPath>
+      <HintPath>..\..\..\..\..\src\LinqToTwitter6\LinqToTwitter.AspNet\bin\Debug\net6.0\LinqToTwitter.dll</HintPath>
     </Reference>
     <Reference Include="LinqToTwitter.AspNet">
-      <HintPath>..\..\..\..\..\src\LinqToTwitter6\LinqToTwitter.AspNet\bin\Debug\net5.0\LinqToTwitter.AspNet.dll</HintPath>
+      <HintPath>..\..\..\..\..\src\LinqToTwitter6\LinqToTwitter.AspNet\bin\Debug\net6.0\LinqToTwitter.AspNet.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/src/LinqToTwitter6/LinqToTwitter.AspNet/OAuth2SessionCredentialStore.cs
+++ b/src/LinqToTwitter6/LinqToTwitter.AspNet/OAuth2SessionCredentialStore.cs
@@ -34,7 +34,7 @@ namespace LinqToTwitter
             }
             set
             {
-                session.SetString("OAuth2ClientID", value);
+                session.SetString("OAuth2ClientID", value ?? string.Empty);
             }
         }
 
@@ -49,7 +49,7 @@ namespace LinqToTwitter
             }
             set
             {
-                session.SetString("OAuth2ClientSecret", value);
+                session.SetString("OAuth2ClientSecret", value ?? string.Empty);
             }
         }
 
@@ -64,7 +64,7 @@ namespace LinqToTwitter
             }
             set
             {
-                session.SetString("OAuth2CodeChallenge", value);
+                session.SetString("OAuth2CodeChallenge", value ?? string.Empty);
             }
         }
 
@@ -103,7 +103,7 @@ namespace LinqToTwitter
             }
             set
             {
-                session.SetString("OAuth2AccessToken", value);
+                session.SetString("OAuth2AccessToken", value ?? string.Empty);
             }
         }
 
@@ -118,7 +118,7 @@ namespace LinqToTwitter
             }
             set
             {
-                session.SetString("OAuth2RefreshToken", (string)value);
+                session.SetString("OAuth2RefreshToken", value ?? string.Empty);
             }
         }
 
@@ -133,7 +133,7 @@ namespace LinqToTwitter
             }
             set
             {
-                session.SetString("OAuth2Callback", value);
+                session.SetString("OAuth2Callback", value ?? string.Empty);
             }
         }
 
@@ -149,7 +149,7 @@ namespace LinqToTwitter
             }
             set
             {
-                session.SetString("OAuth2State", value);
+                session.SetString("OAuth2State", value ?? string.Empty);
             }
         }
 


### PR DESCRIPTION
Fixed NullReferenceException when ASP.NET app, using OAuth2SessionStateCredentialStore, doesn't include offline.access scope. #309 